### PR TITLE
Fixing bugs for search using unavailable state as input and other minor changes

### DIFF
--- a/pathfinding/PriorityQueue.cs
+++ b/pathfinding/PriorityQueue.cs
@@ -47,6 +47,11 @@ public class PriorityQueue<P, V>
 	public void Replace(V value, P oldPriority, P newPriority){
 		LinkedList<V> v = list[oldPriority];
 		v.Remove(value);
+
+		if (v.Count == 0){ // nothing left of the top priority.
+			list.Remove(key);
+		}
+
 		Enqueue(value, newPriority);
 	}
 		

--- a/pathfinding/ShortestPathGraphSearch.cs
+++ b/pathfinding/ShortestPathGraphSearch.cs
@@ -86,9 +86,9 @@ public class ShortestPathGraphSearch<State, Action> {
 
 		frontierMap.Add(fromState, startNode);
 
-		while (true){
-			if (frontier.IsEmpty) return null;
+		while (!frontier.IsEmpty){
 			SearchNode<State,Action> node = frontier.Dequeue();
+			frontierMap.Remove(node.state);
 			
 			if (node.state.Equals(toState)) return BuildSolution(node);
 			exploredSet.Add(node.state);
@@ -105,7 +105,7 @@ public class ShortestPathGraphSearch<State, Action> {
 #else
 					frontier.Enqueue(searchNode,searchNode.f);
 #endif
-					exploredSet.Add(child);
+					frontierMap.Add(child, searchNode);
 				} else if (isNodeInFrontier) {
 					SearchNode<State,Action> searchNode = CreateSearchNode(node, action, child, toState);
 					if (frontierNode.f>searchNode.f){
@@ -118,6 +118,8 @@ public class ShortestPathGraphSearch<State, Action> {
 				}
 			}
 		}
+
+		return null;
 	}
 	
 	private SearchNode<State,Action> CreateSearchNode(SearchNode<State,Action> node, Action action, State child, State toState){


### PR DESCRIPTION
I've caught these bugs while trying to implement this code in another project and trying to use an unavailable state as input for the search.

Fixing following bugs:

Bug 01: Priority list is not removing the key that maps a sub list when it is made empty in a Replace call;
Bug 02: frontierMap wasn't being used at all, in any momment was it being populated with new frontier nodes nor was it cleaned from already checked nodes;

Other changes:

01: Redundant exploredSet.Add(child) after Enqueuing a state (probably it was supposed to be frontierMap.Add(child, searchNode)
02: Removing if (frontier.IsEmpty) return null and using while (!frontier.IsEmpty), just because :)
